### PR TITLE
Fix some cast-function-type warnings introduced in GCC 8

### DIFF
--- a/libegg/eggdesktopfile.c
+++ b/libegg/eggdesktopfile.c
@@ -1302,7 +1302,7 @@ egg_desktop_file_launchv (EggDesktopFile *desktop_file,
  out:
   if (env)
     {
-      g_ptr_array_foreach (env, (GFunc)g_free, NULL);
+      g_ptr_array_set_free_func (env, g_free);
       g_ptr_array_free (env, TRUE);
     }
   free_document_list (translated_documents);


### PR DESCRIPTION
Code from here: https://github.com/mate-desktop/mate-panel/commit/2570b9ab7f8e26c0035bd6fb5401cba99d682ac4