### PR TITLE
travis ci: build only mate-submodule

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -5,17 +5,14 @@ requires:
   archlinux:
     # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/engrampa
     - autoconf-archive
-    - caja
     - clang
-    - file
     - gcc
     - git
     - gtk3
-    - json-glib
+    - libsm
     - make
     - mate-common
     - which
-    - yelp-tools
 
   debian:
     # Useful URL: https://github.com/mate-desktop/debian-packages
@@ -25,34 +22,24 @@ requires:
     - clang
     - clang-tools
     - cppcheck
-    - gettext
     - gcc
     - git
-    - libcaja-extension-dev
     - libglib2.0-dev
     - libgtk-3-dev
-    - libjson-glib-dev
-    - libmagic-dev
     - make
     - mate-common
-    - yelp-tools
 
   fedora:
     # Useful URL: https://src.fedoraproject.org/cgit/rpms/engrampa.git
     - autoconf-archive
-    - caja-devel
     - clang
     - clang-analyzer
-    - desktop-file-utils
-    - file-devel
     - gcc
     - git
     - gtk3-devel
-    - json-glib-devel
     - libSM-devel
     - make
     - mate-common
-    - redhat-rpm-config
 
   ubuntu:
     - autoconf-archive
@@ -60,16 +47,11 @@ requires:
     - clang
     - clang-tools
     - gcc
-    - gettext
     - git
-    - libcaja-extension-dev
     - libglib2.0-dev
     - libgtk-3-dev
-    - libjson-glib-dev
-    - libmagic-dev
     - make
     - mate-common
-    - yelp-tools
 
 variables:
   - 'CHECKERS="
@@ -89,33 +71,13 @@ variables:
     -enable-checker alpha.core.FixedAddr
     -enable-checker security.insecureAPI.strcpy"'
 
-before_scripts:
-  - cd ${START_DIR}
-  - '[ -f mate-common-1.24.1.tar.xz ] || curl -Ls -o mate-common-1.24.1.tar.xz https://github.com/mate-desktop/mate-common/releases/download/v1.24.1/mate-common-1.24.1.tar.xz'
-  - tar xf mate-common-1.24.1.tar.xz
-  - cd mate-common-1.24.1
-  - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
-  -     ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --libexecdir=/usr/lib/x86_64-linux-gnu
-  - else
-  -     ./configure --prefix=/usr
-  - fi
-  - make
-  - make install
-
 build_scripts:
-  - cd ..
-  - git clone --depth 1 https://github.com/mate-desktop/engrampa.git
-  - cd engrampa
-  - cp -dpR ../rootdir/ .
-  - rm -R mate-submodules
-  - mv rootdir mate-submodules
-
   - if [ ${DISTRO_NAME} == "debian" ];then
   -     export CFLAGS+=" -Wsign-compare -Wunused-parameter"
   -     cppcheck --enable=warning,style,performance,portability,information,missingInclude .
   - fi
 
-  - NOCONFIGURE=1 ./autogen.sh
+  - autoreconf -fi
   - scan-build $CHECKERS ./configure --enable-compile-warnings=maximum
   - if [ $CPU_COUNT -gt 1 ]; then
   -     if [ ${DISTRO_NAME} == "debian" ];then

--- a/.build.yml
+++ b/.build.yml
@@ -34,6 +34,7 @@ requires:
     - autoconf-archive
     - clang
     - clang-analyzer
+    - cppcheck-htmlreport
     - gcc
     - git
     - gtk3-devel
@@ -91,4 +92,11 @@ build_scripts:
   -         make clean
   -     fi
   -     scan-build $CHECKERS --keep-cc -o html-report make
+  - fi
+
+after_scripts:
+  - if [ ${DISTRO_NAME} == "fedora" ];then
+  -   cppcheck --xml --output-file=cppcheck.xml --enable=warning,style,performance,portability,information,missingInclude .
+  -   cppcheck-htmlreport --title=${REPO_NAME} --file=cppcheck.xml --report-dir=cppcheck-htmlreport
+  -   ./gen-index -l 20
   - fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,14 @@ addons:
     packages:
       - python3-github
 
+branches:
+  except:
+  - gh-pages
+
 before_install:
   - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/docker-build
-  - chmod +x docker-build
+  - curl -Ls -o gen-index https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/gen-index.sh
+  - chmod +x docker-build gen-index
 
 install:
   - ./docker-build --name ${DISTRO} --config .build.yml --install
@@ -30,6 +35,30 @@ notifications:
       - "[%{branch}] %{commit} %{message} %{build_url}"
     on_success: never
     on_failure: always
+
+deploy:
+  - provider: pages
+    edge: true
+    token: $GITHUB_TOKEN
+    keep_history: false
+    committer_from_gh: true
+    target_branch: gh-pages
+    local_dir: html-report
+    strategy: git
+    on:
+      all_branches: true
+      condition: ${DISTRO} =~ ^fedora.*$
+
+after_success:
+  - 'if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" && "$TRAVIS_PULL_REQUEST" != "false" && ${DISTRO} =~ ^fedora.*$ ]]; then
+        REPO_SLUG_ARRAY=(${TRAVIS_REPO_SLUG//\// });
+        REPO_NAME=${REPO_SLUG_ARRAY[1]};
+        URL="https://${REPO_NAME}.mate-desktop.dev";
+        COMMENT="Code analysis completed";
+        curl -H "Authorization: token $GITHUB_TOKEN" -X POST
+           -d "{\"state\": \"success\", \"description\": \"$COMMENT\", \"context\":\"scan-build\", \"target_url\": \"$URL\"}"
+           https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_PULL_REQUEST_SHA};
+     fi'
 
 env:
   - DISTRO="archlinux:latest"

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,77 @@
+dnl Process this file with autoconf to produce a configure script.
+
+AC_PREREQ(2.61)
+
+AC_INIT([mate-submodules], [1.24.0], [https://mate-desktop.org])
+AM_INIT_AUTOMAKE([1.9 foreign dist-xz no-dist-gzip check-news])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+
+AC_CONFIG_SRCDIR([config.h.in])
+AC_CONFIG_HEADER([config.h])
+AC_CONFIG_MACRO_DIR([m4])
+
+MATE_COMMON_INIT
+MATE_DEBUG_CHECK([no])
+MATE_COMPILE_WARNINGS
+
+AC_PROG_CC
+AM_DISABLE_STATIC
+AC_PROG_LIBTOOL
+PKG_PROG_PKG_CONFIG
+GLIB_GSETTINGS
+
+AC_PATH_PROG(GLIB_GENMARSHAL, glib-genmarshal)
+AC_PATH_PROG(GLIB_MKENUMS, glib-mkenums)
+AC_PATH_PROG(GLIB_COMPILE_RESOURCES, glib-compile-resources)
+
+dnl ==========================================================================
+dnl
+dnl If you add a version number here, you *must* add an AC_SUBST line for
+dnl it too, or it will never make it into the spec file!
+dnl
+dnl ==========================================================================
+
+GLIB_REQUIRED=2.50.0
+GIO_REQUIRED=2.50.0
+GTK_REQUIRED=3.22.0
+
+AC_SUBST(GLIB_REQUIRED)
+AC_SUBST(GIO_REQUIRED)
+AC_SUBST(GTK_REQUIRED)
+
+dnl ===========================================================================
+
+PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= $GTK_REQUIRED])
+AC_SUBST([GTK_CFLAGS])
+AC_SUBST([GTK_LIBS])
+
+LIBEGG_CFLAGS="$GTK_CFLAGS"
+LIBEGG_LIBS="$GTK_LIBS"
+AC_SUBST([LIBEGG_CFLAGS])
+AC_SUBST([LIBEGG_LIBS])
+
+dnl ===========================================================================
+
+PKG_CHECK_MODULES(MS,				\
+	glib-2.0 >= $GLIB_REQUIRED		\
+	gthread-2.0						\
+	gio-unix-2.0 >= $GIO_REQUIRED	\
+	gtk+-3.0 >= $GTK_REQUIRED)
+AC_SUBST(MS_CFLAGS)
+AC_SUBST(MS_LIBS)
+
+dnl ******************************
+
+AC_CONFIG_FILES([Makefile
+		 libegg/Makefile])
+AC_OUTPUT
+
+echo "
+Configuration:
+
+	Source code location:   ${srcdir}
+	Compiler:               ${CC}
+	Compiler flags:         ${CFLAGS}
+	Warning flags:          ${WARN_CFLAGS}
+	Linker flags:           ${LDFLAGS}
+"


### PR DESCRIPTION
This will reduce build time and we are independent from another package.
I am not sure about all the debian stuff under build_scripts: