### PR TITLE
build: Add gthread-2.0 module in PKG_CHECK_MODULES(LIBEGG)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,7 @@ dnl ===========================================================================
 PKG_CHECK_MODULES(LIBEGG, [glib-2.0 >= $GLIB_REQUIRED
                            gtk+-3.0 >= $GTK_REQUIRED
                            sm >= $SM_REQUIRED
+                           gthread-2.0 >= $GLIB_REQUIRED
                            ice >= $ICE_REQUIRED])
 AC_SUBST([LIBEGG_CFLAGS])
 AC_SUBST([LIBEGG_LIBS])


### PR DESCRIPTION
Test
```
$ git grep "LOCK"
libegg/eggdesktopfile.c:G_LOCK_DEFINE_STATIC (egg_desktop_file);
libegg/eggdesktopfile.c:  G_LOCK (egg_desktop_file);
libegg/eggdesktopfile.c:  G_UNLOCK (egg_desktop_file);
libegg/eggdesktopfile.c:  G_LOCK (egg_desktop_file);
libegg/eggdesktopfile.c:  G_UNLOCK (egg_desktop_file);
$ pkg-config --cflags --libs glib-2.0 
-I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -lglib-2.0 
$ pkg-config --cflags --libs gthread-2.0
-pthread -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -lgthread-2.0 -pthread -lglib-2.0 
```