### PR TITLE
build: fix -Wendif-labels warning

### DIFF
--- a/libegg/eggdesktopfile.c
+++ b/libegg/eggdesktopfile.c
@@ -1037,7 +1037,7 @@ set_startup_notification_timeout (GdkDisplay *display,
   g_timeout_add_seconds (EGG_DESKTOP_FILE_SN_TIMEOUT_LENGTH,
 			 startup_notification_timeout, sn_data);
 }
-#endif // GDK_WINDOWING_X11
+#endif /* GDK_WINDOWING_X11 */
 
 static GPtrArray *
 array_putenv (GPtrArray *env, char *variable)
@@ -1242,7 +1242,7 @@ egg_desktop_file_launchv (EggDesktopFile *desktop_file,
 	}
         }
 #else
-      // Suppress unused variable warnings when not compiling with X
+      /* Suppress unused variable warnings when not compiling with X */
       (void)workspace;
       (void)launch_time;
 #endif


### PR DESCRIPTION
Fixes
```
[3/5] Compiling C object libegg/liblibegg.a.p/eggdesktopfile.c.o

../libegg/eggdesktopfile.c:1040:8: warning: extra tokens at end of #endif directive [-Wendif-labels]

 1040 | #endif // GDK_WINDOWING_X11
```

see https://travis-ci.org/github/mate-desktop/mate-submodules/jobs/710287694#L1054