### PR TITLE
cppcheck: parameter 'client' can be declared with const

### DIFF
--- a/libegg/eggsmclient.c
+++ b/libegg/eggsmclient.c
@@ -395,7 +395,7 @@ egg_sm_client_get (void)
  * Return value: %TRUE if the session has been resumed
  **/
 gboolean
-egg_sm_client_is_resumed (EggSMClient *client)
+egg_sm_client_is_resumed (const EggSMClient *client)
 {
     g_return_val_if_fail (client == global_client, FALSE);
 

--- a/libegg/eggsmclient.h
+++ b/libegg/eggsmclient.h
@@ -85,7 +85,7 @@ EggSMClientMode  egg_sm_client_get_mode            (void);
 EggSMClient     *egg_sm_client_get                 (void);
 
 /* Resuming a saved session */
-gboolean         egg_sm_client_is_resumed          (EggSMClient *client);
+gboolean         egg_sm_client_is_resumed          (const EggSMClient *client);
 GKeyFile        *egg_sm_client_get_state_file      (EggSMClient *client);
 
 /* Alternate means of saving state */


### PR DESCRIPTION
```
cppcheck --enable=all --quiet .
```
```
libegg/eggsmclient.c:398:40: style: Parameter 'client' can be declared with const [constParameter]
egg_sm_client_is_resumed (EggSMClient *client)
                                       ^
```