### PR TITLE
Fix build warning about missing field initializer

### DIFF
--- a/libegg/eggsmclient.c
+++ b/libegg/eggsmclient.c
@@ -258,7 +258,7 @@ egg_sm_client_get_option_group (void)
             G_OPTION_ARG_STRING, &sm_config_prefix,
             NULL, NULL
         },
-        { NULL }
+        { NULL, 0,  0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
     };
     GOptionGroup *group;
 

--- a/libegg/eggtreemultidnd.c
+++ b/libegg/eggtreemultidnd.c
@@ -64,14 +64,15 @@ egg_tree_multi_drag_source_get_type (void)
         const GTypeInfo our_info =
         {
             sizeof (EggTreeMultiDragSourceIface), /* class_size */
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            NULL,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            0,
-            0,              /* n_preallocs */
-            NULL
+            NULL,                                 /* base_init */
+            NULL,                                 /* base_finalize */
+            NULL,                                 /* class_init */
+            NULL,                                 /* class_finalize */
+            NULL,                                 /* class_data */
+            0,                                    /* instance_size */
+            0,                                    /* n_preallocs */
+            NULL,                                 /* instance_init */
+            NULL                                  /* value_table */
         };
 
         our_type = g_type_register_static (G_TYPE_INTERFACE, "EggTreeMultiDragSource", &our_info, 0);


### PR DESCRIPTION
```
eggtreemultidnd.c:75:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
        };
        ^
```
```
eggsmclient.c:261:16: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
```