### PR TITLE
Fix some -Wshorten-64-to-32 warnings

### DIFF
--- a/libegg/eggdesktopfile.c
+++ b/libegg/eggdesktopfile.c
@@ -1043,7 +1043,8 @@ set_startup_notification_timeout (GdkDisplay *display,
 static GPtrArray *
 array_putenv (GPtrArray *env, char *variable)
 {
-  guint i, keylen;
+  guint  i;
+  size_t keylen;
 
   if (!env)
     {

--- a/libegg/eggsmclient-xsmp.c
+++ b/libegg/eggsmclient-xsmp.c
@@ -1190,7 +1190,8 @@ array_prop (const char *name, ...)
     va_start (ap, name);
     while ((value = va_arg (ap, char *)))
     {
-        pv.length = strlen (value);
+        size_t length = strlen (value);
+        pv.length = (int)length;
         pv.value = value;
         g_array_append_val (vals, pv);
     }
@@ -1224,7 +1225,8 @@ ptrarray_prop (const char *name, GPtrArray *values)
 
     for (i = 0; i < values->len; i++)
     {
-        pv.length = strlen (values->pdata[i]);
+        size_t length = strlen (values->pdata[i]);
+        pv.length = (int)length;
         pv.value = values->pdata[i];
         g_array_append_val (vals, pv);
     }
@@ -1245,6 +1247,7 @@ static SmProp *
 string_prop (const char *name, const char *value)
 {
     SmProp *prop;
+    size_t  length;
 
     prop = g_new (SmProp, 1);
     prop->name = (char *)name;
@@ -1253,7 +1256,8 @@ string_prop (const char *name, const char *value)
     prop->num_vals = 1;
     prop->vals = g_new (SmPropValue, 1);
 
-    prop->vals[0].length = strlen (value);
+    length = strlen (value);
+    prop->vals[0].length = (int)length;;
     prop->vals[0].value = (char *)value;
 
     return prop;


### PR DESCRIPTION
```
eggdesktopfile.c:1066:12: warning: implicit conversion loses integer precision: 'unsigned long' to 'guint' (aka 'unsigned int') [-Wshorten-64-to-32]
  keylen = strcspn (variable, "=");
         ~ ^~~~~~~~~~~~~~~~~~~~~~~
```
```
eggsmclient-xsmp.c:1193:21: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
        pv.length = strlen (value);
                  ~ ^~~~~~~~~~~~~~
--
eggsmclient-xsmp.c:1227:21: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
        pv.length = strlen (values->pdata[i]);
                  ~ ^~~~~~~~~~~~~~~~~~~~~~~~~
--
eggsmclient-xsmp.c:1256:28: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
    prop->vals[0].length = strlen (value);
                         ~ ^~~~~~~~~~~~~~
```